### PR TITLE
Modified prototype pointer of minHeap

### DIFF
--- a/lib/dataStructures/minHeap.js
+++ b/lib/dataStructures/minHeap.js
@@ -4,7 +4,7 @@ function minHeap() {
   binaryHeap.apply(this, arguments);
 }
 
-minHeap.prototype = new binaryHeap();
+minHeap.prototype = binaryHeap.prototype;
 
 minHeap.prototype.shouldSwap = function (childData, parentData) {
   return childData < parentData;


### PR DESCRIPTION
Made minHeap.prototype point to binaryHeap.prototype instead of the Object returned by new binaryHeap().

This way, minHeap will only have access to the properties we explicitly exposed (i.e removeHead, add, etc).

Because before, with minHeap.prototype = new binaryHeap(), minHeap had direct access to 'this.array', which is not good, as someone can write directly to it.