### PR TITLE
Modified prototype pointer of maxHeap

### DIFF
--- a/lib/dataStructures/maxHeap.js
+++ b/lib/dataStructures/maxHeap.js
@@ -4,7 +4,7 @@ function maxHeap() {
   BinaryHeap.apply(this, arguments);
 }
 
-maxHeap.prototype = new BinaryHeap();
+maxHeap.prototype = BinaryHeap.prototype;
 maxHeap.prototype.shouldSwap = (childData, parentData) => childData > parentData;
 
 module.exports = maxHeap;


### PR DESCRIPTION
Made maxHeap.prototype point to binaryHeap.prototype instead of the Object returned by new BinaryHeap().

This way, maxHeap will only have access to the properties we explicitly exposed (i.e removeHead, add, etc).

Because before, with maxHeap.prototype = new BinaryHeap(), maxHeap had direct access to 'this.array', which is not good, as someone can write directly to it.